### PR TITLE
Fix context usage for oneway apis

### DIFF
--- a/apiserver/grpc/server.go
+++ b/apiserver/grpc/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"time"
 
 	"github.com/projecteru2/pistage/apiserver/grpc/proto"
 	"github.com/projecteru2/pistage/common"
@@ -23,14 +22,12 @@ type GRPCServer struct {
 	stager *stageserver.StageServer
 
 	server  *grpc.Server
-	timeout time.Duration
 }
 
-func NewGRPCServer(store store.Store, stager *stageserver.StageServer, timeoutSecs int) *GRPCServer {
+func NewGRPCServer(store store.Store, stager *stageserver.StageServer) *GRPCServer {
 	return &GRPCServer{
 		store:   store,
 		stager:  stager,
-		timeout: time.Duration(timeoutSecs) * time.Second,
 	}
 }
 
@@ -60,8 +57,7 @@ func (g *GRPCServer) ApplyOneway(ctx context.Context, req *proto.ApplyPistageReq
 	}
 
 	// Discard the output
-	oneWayCtx, _ := context.WithTimeout(context.Background(), g.timeout)
-	g.stager.Add(&common.PistageTask{Ctx: oneWayCtx, Pistage: pistage, JobType: common.JobTypeApply, Output: common.ClosableDiscard})
+	g.stager.Add(&common.PistageTask{Ctx: context.Background(), Pistage: pistage, JobType: common.JobTypeApply, Output: common.ClosableDiscard})
 
 	return &proto.ApplyPistageOnewayReply{
 		WorkflowType:       pistage.WorkflowType,
@@ -104,8 +100,7 @@ func (g *GRPCServer) RollbackOneway(ctx context.Context, req *proto.RollbackPist
 	}
 
 	// Discard the output
-	oneWayCtx, _ := context.WithTimeout(context.Background(), g.timeout)
-	g.stager.Add(&common.PistageTask{Ctx: oneWayCtx, Pistage: pistage, JobType: common.JobTypeRollback, Output: common.ClosableDiscard})
+	g.stager.Add(&common.PistageTask{Ctx: context.Background(), Pistage: pistage, JobType: common.JobTypeRollback, Output: common.ClosableDiscard})
 
 	return &proto.RollbackReply{
 		WorkflowType:       pistage.WorkflowType,

--- a/cmd/pistage/server/server.go
+++ b/cmd/pistage/server/server.go
@@ -44,7 +44,7 @@ func StartPistage(c *cli.Context) error {
 	s.Start()
 	logrus.Info("[Stager] started")
 
-	g := grpc.NewGRPCServer(store, s, config.DefaultJobExecuteTimeoutSecs)
+	g := grpc.NewGRPCServer(store, s)
 	go g.Serve(l)
 	logrus.Info("[GRPCServer] started")
 

--- a/stageserver/server.go
+++ b/stageserver/server.go
@@ -57,7 +57,7 @@ func (s *StageServer) runner(id int) {
 			logrus.WithField("runner id", id).Info("[Stager] runner stopped")
 			return
 		case pt := <-s.stages:
-			r := NewRunner(pt, s.store)
+			r := NewRunner(pt, s.store, s.config.DefaultJobExecuteTimeoutSecs)
 			// if err := s.runWithGraph(pt); err != nil {
 			// 	logrus.WithField("pistage", pt.Pistage.WorkflowIdentifier).WithError(err).Errorf("[Stager runner] error when running a pistage")
 			// }


### PR DESCRIPTION
The purpose of passing a context into a method is to control the lifecycle of the method from outside the method.

For oneway methods, setting a timer is actually to control the lifecycle within the method. So no need to generate and pass the context outside the method.